### PR TITLE
Retire this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Retired and unmaintained
+
+Nobody is using this project, so we have decided to retire it. Do not use - it is unmaintained and has many dependencies with known vulnerabilities.
+
 # EasyGA Track everything, everywhere.
 
 EasyGA is a JavaScript layer on top of Google Analytics which automatically tracks all events, views, links and other metrics without requiring any additional JavaScript code to be written. Just include the library, set the tracking code and go!


### PR DESCRIPTION
https://trello.com/c/OS5OSEVl

I've done a search, and I cannot find anyone using this project - either in alphagov or outside. It's got a number of vulnerable dependencies (one critical). Given the lack of users, I propose retiring it rather than maintaining it.

Once this has been merged, I'll archive and then move it to https://github.com/Crown-Commercial-Service alongside the other archived repos the Digital Marketplace team are admins of.